### PR TITLE
avoid 'sockaddr' struct redefinition error

### DIFF
--- a/Core/libMOOS/include/MOOS/libMOOS/MOOSLib.h
+++ b/Core/libMOOS/include/MOOS/libMOOS/MOOSLib.h
@@ -38,9 +38,9 @@
 
 #ifdef _WIN32
     #include <winsock2.h>
-    #include "windows.h"
     #include "winbase.h"
     #include "winnt.h"
+    #include "windows.h"
 #endif
 
 


### PR DESCRIPTION
"windows.h" must be the last file included to avoid redefinition error
