### PR TITLE
avoid 'sockaddr' struct redefinition error in MOOSLock

### DIFF
--- a/Core/libMOOS/Utils/include/MOOS/libMOOS/Utils/MOOSLock.h
+++ b/Core/libMOOS/Utils/include/MOOS/libMOOS/Utils/MOOSLock.h
@@ -41,9 +41,10 @@
 
 //some conditional stuff..
 #ifdef _WIN32
-    #include "windows.h"
+    #include <winsock2.h>
     #include "winbase.h"
     #include "winnt.h"
+    #include "windows.h"
 #else
     #include <pthread.h>
 #endif


### PR DESCRIPTION
"winsock2.h" must be included
"windows.h" must be the last file included to avoid redefinition error
