### PR TITLE
Add support for configuration files written in Lua

### DIFF
--- a/Core/libMOOS/CMakeLists.txt
+++ b/Core/libMOOS/CMakeLists.txt
@@ -42,8 +42,8 @@ SET(UTILS_SOURCES
    Utils/ThreadPriority.cpp
    Utils/PeriodicEvent.cpp
    Utils/ConsoleColours.cpp
-   
-   
+   Utils/MOOSLuaEnvironment.cpp
+   Utils/MOOSLuaConfig.cpp
    )
 
 IF(WIN32)
@@ -174,8 +174,22 @@ set(${LIBNAME}_DEPEND_INCLUDE_DIRS
 )
 list(REMOVE_DUPLICATES ${LIBNAME}_DEPEND_INCLUDE_DIRS)
 
+
+############# Lua
+
+FIND_PACKAGE(Lua51 REQUIRED)
+IF(LUA51_FOUND)
+  message( "-- Lua 5.1 found" )
+ELSE(LUA51_FOUND)
+  message( FATAL_ERROR "Error: Lua 5.1 library not found, it is required to build" )
+ENDIF(LUA51_FOUND)
+
+INCLUDE_DIRECTORIES(${LUA_INCLUDE_DIR})
+
+
+
 if(UNIX)
-    set(DEPENDENCIES pthread m)
+    set(DEPENDENCIES pthread m lua5.1)
 endif(UNIX)
 
 IF(WIN32)

--- a/Core/libMOOS/Utils/MOOSLuaConfig.cpp
+++ b/Core/libMOOS/Utils/MOOSLuaConfig.cpp
@@ -1,0 +1,227 @@
+///////////////////////////////////////////////////////////////////////////
+//
+//   This file is part of the MOOS project
+//
+//   MOOS : Mission Oriented Operating Suite A suit of
+//   Applications and Libraries for Mobile Robotics Research
+//   Copyright (C) Paul Newman
+//
+//   This software was written by Paul Newman at MIT 2001-2002 and
+//   the University of Oxford 2003-2013
+//
+//   email: pnewman@robots.ox.ac.uk.
+//
+//   This file was written by Ian Katz at MIT 2010 (ijk5@mit.edu)
+//
+//   This source code and the accompanying materials
+//   are made available under the terms of the GNU Lesser Public License v2.1
+//   which accompanies this distribution, and is available at
+//   http://www.gnu.org/licenses/lgpl.txtgram is distributed in the hope that it will be useful,
+//   but WITHOUT ANY WARRANTY; without even the implied warranty of
+//   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#include "MOOS/libMOOS/Utils/MOOSLuaConfig.h"
+#include "MOOS/libMOOS/Utils/MOOSUtilityFunctions.h"
+
+CMOOSLuaConfig::CMOOSLuaConfig(string sIdentifier,
+                               LUA_API_MAP api, 
+                               string sLuaLibDir)
+    : CMOOSLuaEnvironment(sIdentifier, api, CMOOSLuaConfig::Lua_OnErr, sLuaLibDir) {}
+
+
+bool CMOOSLuaConfig::GetConfiguration(std::string sAppName, STRING_LIST &Params)
+{
+    bool bGotRet = false;
+    string sKey, sVal;
+
+    //get var that we want
+    lua_getglobal(m_luaState, sAppName.c_str());
+
+    //make sure the requested section (table) was found
+    if (LUA_TTABLE != lua_type(m_luaState, -1))
+    {
+        lua_pop(m_luaState, 1);
+        return false;
+    }
+
+    lua_pushnil(m_luaState); // push dummy key and iterate... based on common example
+
+    while(lua_next(m_luaState, -2)) 
+    {
+        //avoid calling lua_tostring on a non-string key... messes up lua_next 
+        if (LUA_TSTRING == lua_type(m_luaState, -2))
+        {
+            sKey = lua_tostring(m_luaState, -2);
+            
+            switch (lua_type(m_luaState, -1))
+            {
+                
+            case LUA_TSTRING:
+            case LUA_TNUMBER:
+            case LUA_TBOOLEAN:
+                sVal = myToString(-1);
+                MOOSRemoveChars(sVal, " \t\r"); // emulate shitty behavior of original MOOS
+                Params.push_front(sKey + "=" + sVal);
+                break;
+
+            case LUA_TTABLE:
+                //return all entries under same key name
+                lua_pushnil(m_luaState); //dummy key again
+
+                while (lua_next(m_luaState, -2))
+                {
+                    sVal = myToString(-1);
+                    MOOSRemoveChars(sVal," \t\r"); // emulate shitty behavior of original MOOS
+                    Params.push_front(sKey + "=" + sVal);
+                    lua_pop(m_luaState, 1); // pop value and keep key
+                }
+                break;
+                
+            case LUA_TNIL: //blank line
+                Params.push_front(sKey + "=");
+                break;
+
+            default:                // do nothing
+                break;
+
+            } // switch
+            
+//            lua_pop(m_luaState, 1); //pop value
+
+        } // if key is a string
+
+        lua_pop(m_luaState, 1); // pop the value, keep the key
+    } // while
+
+        
+    lua_pop(m_luaState, 1); //pop the table
+
+    return true;
+
+}
+
+
+bool CMOOSLuaConfig::GetConfigurationParam(std::string sAppName, string sParam, string &sVal)
+{
+    bool bGotVar = false;
+    bool bGotRet = false;
+    string sKey;
+
+    //get var that we want
+    lua_getglobal(m_luaState, sAppName.c_str());
+
+    //make sure the requested section (table) was found
+    if (LUA_TTABLE != lua_type(m_luaState, -1))
+    {
+        lua_pop(m_luaState, 1);
+        return false;
+    }
+
+    lua_pushnil(m_luaState); // push dummy key and iterate... based on common example
+
+    while(lua_next(m_luaState, -2)) 
+    {
+        //avoid calling lua_tostring on a non-string key... messes up lua_next 
+        if (LUA_TSTRING == lua_type(m_luaState, -2))
+        {
+            sKey = lua_tostring(m_luaState, -2);
+            
+            if (MOOSStrCmp(sKey, sParam))
+            {
+                switch (lua_type(m_luaState, -1))
+                {
+                case LUA_TSTRING:
+                case LUA_TNUMBER:
+                case LUA_TBOOLEAN:
+                    bGotVar = true;
+                    bGotRet = true;
+                    sVal = myToString(-1);
+                    break;
+                    
+                case LUA_TTABLE:
+                    //return last entry if there is one
+                    bGotVar = true;
+                    lua_pushnil(m_luaState); //dummy key again
+
+                    while (lua_next(m_luaState, -2))
+                    {
+                        bGotRet = true;
+                        sVal = myToString(-1);
+                        lua_pop(m_luaState, 1); // pop value and keep key
+                    }
+                    break;
+
+                default: //break 
+                    bGotVar = true;
+                    break;
+
+
+                } // switch
+
+                if (bGotVar) 
+                {
+                    lua_pop(m_luaState, 2); //pop key & value
+                    break;
+                } 
+
+            } // if right key
+
+        } // if key is a string
+
+        lua_pop(m_luaState, 1); // pop the value, keep the key
+    } // while
+
+        
+    lua_pop(m_luaState, 1); //pop the table
+    
+    MOOSRemoveChars(sVal," \t\r");
+    return bGotRet;
+
+}
+
+//this just looks up the value of a global
+bool CMOOSLuaConfig::GetValue(std::string sName, std::string &sResult)
+{
+    //get it from the globals section
+    return GetConfigurationParam("_G", sName, sResult);
+}
+
+std::string CMOOSLuaConfig::myToString(int idx)
+{
+    if (idx < 0)
+    {
+        idx = lua_gettop(m_luaState) + idx + 1;
+    }
+
+    std::string sResult = "";
+
+    // table ? make it a string
+    if (lua_istable(m_luaState, idx)) 
+    {
+        std::stringstream os;
+        sResult += "{\n";
+        lua_pushnil(m_luaState);
+        while(lua_next(m_luaState, -2)) 
+        {
+            sResult += "[" + myToString(-2)
+                + "]=" + myToString(-1) + ",\n";
+
+            lua_pop(m_luaState, 1); // pop the value, keep the key
+        }
+        sResult += "}\n";
+        return sResult;
+
+    } 
+    else 
+    {
+        //run lua's tostring function
+        lua_getglobal(m_luaState, "tostring");
+        lua_pushvalue(m_luaState, idx);
+        lua_pcall(m_luaState, 1, 1, 0);
+        sResult = lua_tostring(m_luaState, -1);
+        lua_pop(m_luaState, 1);
+        return sResult;
+    }
+}

--- a/Core/libMOOS/Utils/MOOSLuaEnvironment.cpp
+++ b/Core/libMOOS/Utils/MOOSLuaEnvironment.cpp
@@ -1,0 +1,317 @@
+///////////////////////////////////////////////////////////////////////////
+//
+//   This file is part of the MOOS project
+//
+//   MOOS : Mission Oriented Operating Suite A suit of
+//   Applications and Libraries for Mobile Robotics Research
+//   Copyright (C) Paul Newman
+//
+//   This software was written by Paul Newman at MIT 2001-2002 and
+//   the University of Oxford 2003-2013
+//
+//   email: pnewman@robots.ox.ac.uk.
+//
+//   This file was written by Ian Katz at MIT 2010 (ijk5@mit.edu)
+//
+//   This source code and the accompanying materials
+//   are made available under the terms of the GNU Lesser Public License v2.1
+//   which accompanies this distribution, and is available at
+//   http://www.gnu.org/licenses/lgpl.txtgram is distributed in the hope that it will be useful,
+//   but WITHOUT ANY WARRANTY; without even the implied warranty of
+//   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//
+////////////////////////////////////////////////////////////////////////////
+
+
+#include "MOOS/libMOOS/Utils/MOOSLuaEnvironment.h"
+#include "MOOS/libMOOS/Utils/MOOSUtilityFunctions.h"
+
+
+/**
+ * Lua environment initialization
+ *
+ * Export some useful functions to lua
+ */
+CMOOSLuaEnvironment::CMOOSLuaEnvironment(string sIdentifier,
+                                         LUA_API_MAP api, 
+                                         void (*OnError)(string, string),
+                                         string sLuaLibDir)
+{
+    m_bDebug = false;
+
+    m_sLuaFilename = "";
+    m_sLuaLibdir = sLuaLibDir;
+    m_sIdentifier = sIdentifier;
+    m_sLastError = "(no error)";
+
+    m_OnError = OnError;
+
+    InitLua(api);
+    
+}
+
+
+CMOOSLuaEnvironment::~CMOOSLuaEnvironment()
+{
+    lua_close(m_luaState);
+}
+
+//set up a lua environment around the supplied lua file
+int CMOOSLuaEnvironment::Load(string filename)
+{
+    const char *msg;
+
+    //try to load; on error, record message and bail immediately
+    int ret = luaL_loadfile(m_luaState, filename.c_str());
+    if (ret) 
+    {
+        msg = lua_tostring(m_luaState, -1);
+        if (msg == NULL) msg = "(error with no message)";
+        m_sLastError = msg;
+        lua_pop(m_luaState, 1); // remove error message from stack
+
+        return ret;
+    }
+
+    //"run" file, to load functions etc
+    if (lua_pcall(m_luaState, 0, LUA_MULTRET, 0)) 
+    {
+        msg = lua_tostring(m_luaState, -1);
+        if (msg == NULL) msg = "(error with no message)";
+        m_sLastError = msg;
+        lua_pop(m_luaState, 1); // remove error message from stack
+
+        return 1;
+    }
+
+    //successful; record filename
+    m_sLuaFilename = filename;
+    m_sLastError = "(No Error)";
+    
+    return 0;
+}
+
+//if a lua error occurred on load, this returns the text of the error message
+string CMOOSLuaEnvironment::LastLoadError()
+{
+    return m_sLastError;
+}
+
+//create an empty lua state with libraries and API functions
+void CMOOSLuaEnvironment::InitLua(LUA_API_MAP api)
+{
+    m_luaState = luaL_newstate();
+    luaL_openlibs(m_luaState);
+
+    //register API functions as per the map: "funcInLua" => HAPI_func_pointer
+    for (LUA_API_MAP::iterator it = api.begin(); it != api.end(); it++)
+    {
+        lua_register(m_luaState, it->first.c_str(), it->second);
+    }
+
+    //initialize the lua libdir to the stored val: edit package.path
+    lua_getglobal(m_luaState, "package"); // pull up package on stack
+    if (!lua_istable(m_luaState, -1))
+    {
+        printf("CMOOSLuaEnvironment::SetLibDir: package is not a table\n");
+    }
+    else
+    {
+        //incorporate both files and packages in the lib dir
+        string libs = m_sLuaLibdir + "/?.lua;" + m_sLuaLibdir + "/?/init.lua";
+        lua_pushstring(m_luaState, libs.c_str());
+        lua_setfield(m_luaState, -2, "path");
+    }
+    lua_pop(m_luaState, 1); //remove "package" from stack
+}
+
+//close down a lua environment and open it with a different API
+//TODO: possible problems can be caused by switching the API at a bad time
+//      - can eliminate this by compiling during the test phase and loading the 
+//        compiled version
+void CMOOSLuaEnvironment::SwitchAPI(LUA_API_MAP api, void (*OnError)(string, string))
+{
+    MOOSTrace("Switching Lua API in %s\n", m_sIdentifier.c_str());
+    lua_close(m_luaState);
+    
+    InitLua(api);
+    
+    m_OnError = OnError;
+
+    //reload file in the new environment
+    if ("" != m_sLuaFilename)
+    {
+        Load(m_sLuaFilename);
+    }
+}
+
+//print a helpful stack dump
+void CMOOSLuaEnvironment::StackDump(lua_State* l)
+{
+    int i;
+    int top = lua_gettop(l);
+
+    MOOSTrace("total in stack %d\n", top);
+
+    for (i = top; i >= 1; i--)
+    {  
+        int t = lua_type(l, i);
+        switch (t) 
+        {
+        case LUA_TSTRING:  /* strings */
+            MOOSTrace("  string: '%s'\n", lua_tostring(l, i));
+            break;
+        case LUA_TBOOLEAN:  /* booleans */
+            MOOSTrace("  boolean %s\n",lua_toboolean(l, i) ? "true" : "false");
+            break;
+        case LUA_TNUMBER:  /* numbers */
+            MOOSTrace("  number: %g\n", lua_tonumber(l, i));
+            break;
+        default:  /* other values */
+            MOOSTrace("  %s\n", lua_typename(l, t));
+            break;
+        }
+
+    }
+    MOOSTrace("\n");  /* end the listing */
+}
+
+//look for function in lua environment
+bool CMOOSLuaEnvironment::LuaFuncExists(string func)
+{
+    lua_getglobal(m_luaState, func.c_str());
+    bool ret = lua_isfunction(m_luaState, -1); 
+    lua_pop(m_luaState, 1);
+    return ret;
+}
+
+//look for variable in lua environment... exists and is not function
+bool CMOOSLuaEnvironment::LuaVariableExists(string func)
+{
+    lua_getglobal(m_luaState, func.c_str());
+    bool ret = !lua_isnil(m_luaState, -1) && !lua_isfunction(m_luaState, -1);
+    lua_pop(m_luaState, 1);
+    return ret;
+}
+
+//turn error code into (more) helpful message
+string CMOOSLuaEnvironment::LuaErrorDesc(int resultcode)
+{
+    switch (resultcode)
+     {
+     case 0:
+         return "Success";
+     case 1:
+         return "Error running file";
+     case LUA_ERRRUN:
+         return "Runtime error";
+     case LUA_ERRSYNTAX:
+         return "Syntax error";
+     case LUA_ERRMEM:
+         return "Memory allocation error";
+     case LUA_ERRERR:
+         return "Improperly configured error alert mechanism.  FAIL FAIL.";
+     case LUA_ERRFILE:
+         return "File access error";
+     default:
+         return MOOSFormat("Unknown Lua error with code '%d'", resultcode);
+     }
+}
+
+//put an error handler on the stack and let us know where it ended up
+int CMOOSLuaEnvironment::SetLuaErrHandler()
+{
+    if (m_bDebug)
+    {
+        MOOSTrace("Dump before setting %s error handler: \n", m_sIdentifier.c_str());
+        StackDump(m_luaState);
+    }
+
+    //set up traceback on stack
+    lua_getglobal(m_luaState, "debug");
+    lua_getfield(m_luaState, -1, "traceback");
+    lua_remove(m_luaState, -2);
+
+    return lua_gettop(m_luaState);
+}
+
+//call lua with error handling
+// err_handler_loc is a stack location
+int CMOOSLuaEnvironment::CallLua(int num_args, int num_results, int err_handler_loc)
+{
+    if (m_bDebug)
+    {
+        MOOSTrace("Dump before %s call (err handler at %d): \n", m_sIdentifier.c_str(), err_handler_loc);
+        StackDump(m_luaState);
+    }
+
+    int ret = lua_pcall(m_luaState, num_args, num_results, err_handler_loc);
+
+    if (ret)
+    {
+        //report the non-success error, let the owner handle it
+        (*m_OnError)(Identifier(), MOOSFormat("%s: %s", 
+                                              LuaErrorDesc(ret).c_str(),
+                                              lua_tostring(m_luaState, -1)));
+    }
+
+    return ret;
+
+}
+
+//call a lua function that doesn't take arguments
+int CMOOSLuaEnvironment::CallLuaVoid(string func, int num_results)
+{
+    if (m_bDebug)
+    {
+        MOOSTrace("Calling %s:%s\n", m_sIdentifier.c_str(), func.c_str());
+    }
+    int myErrHandler = SetLuaErrHandler();
+    //printf("error handler at pos %d\n", myErrHandler);
+
+    //put function on stack and go for it
+    lua_getglobal (m_luaState, func.c_str());
+
+    return CallLua(0, num_results, myErrHandler);
+}
+
+//clean up the stack after a lua call
+void CMOOSLuaEnvironment::CallLuaCleanup()
+{ 
+    if (m_bDebug)
+    {
+        MOOSTrace("Dump before %s cleanup: \n", m_sIdentifier.c_str());
+        StackDump(m_luaState);
+    }
+    lua_pop(m_luaState, 1);
+}
+
+//these functions are for building the fields of a table which is already on the stack
+void CMOOSLuaEnvironment::BuildLuaTable(string key, bool value, int tableindex)
+{
+    lua_pushstring(m_luaState, key.c_str());
+    lua_pushboolean(m_luaState, value);
+    lua_settable(m_luaState, tableindex);
+}
+
+void CMOOSLuaEnvironment::BuildLuaTable(string key, int value, int tableindex)
+{
+    lua_pushstring(m_luaState, key.c_str());
+    lua_pushinteger(m_luaState, value);
+    lua_settable(m_luaState, tableindex);
+}
+
+void CMOOSLuaEnvironment::BuildLuaTable(string key, double value, int tableindex)
+{
+    lua_pushstring(m_luaState, key.c_str());
+    lua_pushnumber(m_luaState, value);
+    lua_settable(m_luaState, tableindex);
+}
+
+void CMOOSLuaEnvironment::BuildLuaTable(string key, string value, int tableindex)
+{
+    lua_pushstring(m_luaState, key.c_str());
+    lua_pushstring(m_luaState, value.c_str());
+    lua_settable(m_luaState, tableindex);
+}
+

--- a/Core/libMOOS/Utils/ProcessConfigReader.cpp
+++ b/Core/libMOOS/Utils/ProcessConfigReader.cpp
@@ -132,6 +132,14 @@ bool CProcessConfigReader::GetConfigurationAndPreserveSpace(std::string sAppName
 
 bool CProcessConfigReader::GetConfiguration(std::string sAppName, STRING_LIST &Params)
 {
+
+    // try Lua first
+    if (m_LuaCfg)
+    {
+        return m_LuaCfg->GetConfiguration(sAppName, Params);
+    }
+
+    // else, backwards compatibility
     
     int nBrackets = 0;
     Params.clear();
@@ -300,6 +308,15 @@ bool CProcessConfigReader::GetConfigurationParam(std::string sAppName,std::strin
 
 bool CProcessConfigReader::GetConfigurationParam(std::string sAppName,std::string sParam, std::string &sVal)
 {
+
+    // try Lua first
+    if (m_LuaCfg)
+    {
+        return m_LuaCfg->GetConfigurationParam(sAppName, sParam, sVal);
+    }
+
+    // else, backwards compatibility
+
     Reset();
     
     STRING_LIST sParams;

--- a/Core/libMOOS/Utils/include/MOOS/libMOOS/Utils/MOOSFileReader.h
+++ b/Core/libMOOS/Utils/include/MOOS/libMOOS/Utils/MOOSFileReader.h
@@ -39,6 +39,7 @@
 #include <fstream>
 #include <string>
 #include <map>
+#include "MOOS/libMOOS/Utils/MOOSLuaConfig.h"
 
 #ifdef _WIN32
     typedef std::map<int,std::ifstream*> THREAD2FILE_MAP;
@@ -117,7 +118,8 @@ protected:
 		}
 		m_FileMap.clear();
 	}
-	
+
+    CMOOSLuaConfig* m_LuaCfg;
 	
     std::ifstream * GetFile();
     CMOOSLock *m_pLock;

--- a/Core/libMOOS/Utils/include/MOOS/libMOOS/Utils/MOOSLuaConfig.h
+++ b/Core/libMOOS/Utils/include/MOOS/libMOOS/Utils/MOOSLuaConfig.h
@@ -1,0 +1,79 @@
+///////////////////////////////////////////////////////////////////////////
+//
+//   This file is part of the MOOS project
+//
+//   MOOS : Mission Oriented Operating Suite A suit of
+//   Applications and Libraries for Mobile Robotics Research
+//   Copyright (C) Paul Newman
+//
+//   This software was written by Paul Newman at MIT 2001-2002 and
+//   the University of Oxford 2003-2013
+//
+//   email: pnewman@robots.ox.ac.uk.
+//
+//   This file was written by Ian Katz at MIT 2010 (ijk5@mit.edu)
+//
+//   This source code and the accompanying materials
+//   are made available under the terms of the GNU Lesser Public License v2.1
+//   which accompanies this distribution, and is available at
+//   http://www.gnu.org/licenses/lgpl.txtgram is distributed in the hope that it will be useful,
+//   but WITHOUT ANY WARRANTY; without even the implied warranty of
+//   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//
+////////////////////////////////////////////////////////////////////////////
+//
+// MOOSLuaConfig.h - interface for the CMOOSLuaConfig class
+//
+/////////////////////////////////////
+
+
+#if !defined(AFX_MOOSLUACONFIG_H_INCLUDED_)
+#define AFX_MOOSLUACONFIG_H_INCLUDED_
+
+
+#include "MOOSLuaEnvironment.h"
+#include <lua5.1/lua.hpp>
+#include <string>
+
+
+using namespace std;
+
+
+class CMOOSLuaConfig : public CMOOSLuaEnvironment
+{
+public:
+
+    CMOOSLuaConfig(std::string sIdentifier,
+                   LUA_API_MAP api, 
+                   std::string sLuaLibDir);
+
+    
+    virtual ~CMOOSLuaConfig() {};
+
+
+    // 3 functions to get data in the style of the mission config reader
+    bool GetConfiguration(std::string sAppName,
+                          STRING_LIST &Params);
+    
+    bool GetConfigurationParam(std::string sAppName,
+                               std::string sParam,
+                               std::string &sVal);
+    
+    bool GetValue(std::string sName, std::string &sResult);
+    
+
+protected:
+
+    //print an error to the console
+    static void Lua_OnErr(string source, string message)
+    {
+        MOOSTrace("Lua Error from %s:\n    %s\n",
+                  source.c_str(), message.c_str());
+    }
+
+    
+    std::string myToString(int idx);
+
+};
+
+#endif // !defined(AFX_MOOSLUACONFIG_H_INCLUDED_)

--- a/Core/libMOOS/Utils/include/MOOS/libMOOS/Utils/MOOSLuaEnvironment.h
+++ b/Core/libMOOS/Utils/include/MOOS/libMOOS/Utils/MOOSLuaEnvironment.h
@@ -1,0 +1,129 @@
+///////////////////////////////////////////////////////////////////////////
+//
+//   This file is part of the MOOS project
+//
+//   MOOS : Mission Oriented Operating Suite A suit of
+//   Applications and Libraries for Mobile Robotics Research
+//   Copyright (C) Paul Newman
+//
+//   This software was written by Paul Newman at MIT 2001-2002 and
+//   the University of Oxford 2003-2013
+//
+//   email: pnewman@robots.ox.ac.uk.
+//
+//   This file was written by Ian Katz at MIT 2010 (ijk5@mit.edu)
+//
+//   This source code and the accompanying materials
+//   are made available under the terms of the GNU Lesser Public License v2.1
+//   which accompanies this distribution, and is available at
+//   http://www.gnu.org/licenses/lgpl.txtgram is distributed in the hope that it will be useful,
+//   but WITHOUT ANY WARRANTY; without even the implied warranty of
+//   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//
+////////////////////////////////////////////////////////////////////////////
+//
+// MOOSLuaEnvironment.h - interface for the CMOOSLuaEnvironment class
+//
+/////////////////////////////////////
+
+
+#if !defined(AFX_MOOSLUAENVIRONMENT_H_INCLUDED_)
+#define AFX_MOOSLUAENVIRONMENT_H_INCLUDED_
+
+#include "MOOS/libMOOS/Utils/MOOSUtilityFunctions.h"
+#include <lua5.1/lua.hpp>
+#include <string>
+#include <map>
+#include <set>
+
+using namespace std;
+
+typedef map<string, lua_CFunction> LUA_API_MAP;
+
+enum LuaApiRetcode
+{
+    LAPI_SUCCESS = 0,
+    LAPI_ARGC_FAIL,
+    LAPI_RANGE_FAIL,
+    LAPI_CMD_FAIL,
+    LAPI_DTYPE_FAIL,
+};
+
+
+class CMOOSLuaEnvironment
+{
+public:
+    CMOOSLuaEnvironment(string sIdentifier,
+                        LUA_API_MAP api, 
+                        void (*OnError)(string, string),
+                        string sLuaLibDir);
+
+    virtual ~CMOOSLuaEnvironment();
+    
+    //put a function in the environment
+    int Load(string filename);
+
+    //get the last error message from a load operation
+    string LastLoadError();
+
+    //identifier for this mission container (safety, surface, mission)
+    string Identifier() { return m_sIdentifier; }
+
+    //filename
+    string Filename() { return m_sLuaFilename; }
+
+    //re-open the lua environment with a new API
+    void SwitchAPI(LUA_API_MAP api, void (*OnError)(string, string));
+
+    //get a meaningful error description
+    static string LuaErrorDesc(int resultcode);
+
+    //toggle debugging messages
+    void SetDebug(bool enabled) { m_bDebug = enabled; }
+
+protected:
+
+    lua_State* m_luaState;
+    string m_sIdentifier;
+    string m_sLuaFilename;
+    string m_sLuaLibdir;
+    string m_sLastError;
+    bool m_bDebug;
+
+    void (*m_OnError)(string, string);
+
+    void InitLua(LUA_API_MAP api);
+    
+    //find out whether a function exists in the environment
+    bool LuaFuncExists(string func);
+
+    //find out whether a variable exists in the environment
+    bool LuaVariableExists(string varname);
+
+    void StackDump(lua_State* l);
+    
+    //wrapper for LuaFuncExists that prints an error message
+    bool CheckFunction(bool initial, string func);
+
+    //call a function in the lua environment that takes no arguments
+    int CallLuaVoid(string func, int num_results);
+    
+    //after pushing a function onto the stack, call it and handle its result
+    int CallLua(int num_args, int num_results, int err_handler_loc);
+
+    //take the error handler off the stack
+    void CallLuaCleanup();
+
+    //put an error handling function on the stack and return its index
+    int SetLuaErrHandler();
+    
+    //one liners for adding an entry to a table (string key)
+    void BuildLuaTable(string key, bool value, int tableindex);
+    void BuildLuaTable(string key, int value, int tableindex);
+    void BuildLuaTable(string key, double value, int tableindex);
+    void BuildLuaTable(string key, string value, int tableindex);
+
+};
+
+#endif // !defined(AFX_MOOSLUAENVIRONMENT_H_INCLUDED_)
+

--- a/Core/libMOOS/Utils/include/MOOS/libMOOS/Utils/MOOSLuaEnvironment.h
+++ b/Core/libMOOS/Utils/include/MOOS/libMOOS/Utils/MOOSLuaEnvironment.h
@@ -66,7 +66,7 @@ public:
     //get the last error message from a load operation
     string LastLoadError();
 
-    //identifier for this mission container (safety, surface, mission)
+    //identifier for this environment, used in debug messages
     string Identifier() { return m_sIdentifier; }
 
     //filename


### PR DESCRIPTION
This patch (against master, not devel) adds support for configuration files written in Lua, arguably a better way to represent configuration.
## Example

.moos Syntax:

```
ServerHost = localhost
ServerPort = 9000 
// this is a comment 
ProcessConfig = pLuaCfg
{ 
    aString = MyStringValueNoSpaces
    aSpacedString = S P A C E S 

    aDouble = 3.141 

    aBoolTrue = true 
    aBoolNotTrue = false 

    aMultiString = a 
    aMultiString = b 
    aMultiString = and so on 

    aNullVal = 
}
```

Lua Syntax (same data)

``` lua
ServerHost = "localhost"
ServerPort = 9000 
-- this is a comment 
pLuaCfg = { 
    aString = "MyStringValueNoSpaces", 
    aSpacedString = ("S P A C E S"):gsub(" ", ""), 

    aDouble = 3.141, 

    aBoolTrue = true, 
    aBoolNotTrue = false, 

    aMultiString = { 
                    "a", 
                    "b", 
                    ("and so on"):gsub(" ", ""), }, 

    aNullVal = nil, 
}
```
## Backwards Compatibility

Configuration files will be loaded into a Lua environment.  If that fails (i.e., if they do not parse), then the file will be parsed as a normal .moos file.
## Extras

This code supples MOOSLuaEnvironment, which allows other uses of Lua files in MOOS.  For example, as a Lua scripted MOOS App.

Slides here: http://oceanai.mit.edu/moos-dawg11/material/23-brief-katz.pdf
