### PR TITLE
Patch to have CMake configure a new header file (ClientDefines.h) with t...

### DIFF
--- a/Core/libMOOS/App/include/MOOS/libMOOS/App/MOOSApp.h
+++ b/Core/libMOOS/App/include/MOOS/libMOOS/App/MOOSApp.h
@@ -41,6 +41,7 @@
 #include "MOOS/libMOOS/Comms/MOOSCommClient.h"
 #include "MOOS/libMOOS/Comms/MOOSVariable.h"
 
+#include "MOOS/libMOOS/App/ClientDefines.h"
 
 #include <set>
 #include <map>

--- a/Core/libMOOS/CMakeLists.txt
+++ b/Core/libMOOS/CMakeLists.txt
@@ -95,15 +95,8 @@ include(PlatformDefines)
 #do we want to use the new fast asynchronous client architecture?
 OPTION(USE_ASYNC_COMMS  "enable fast asynchronous comms architecture" ON)
 IF (USE_ASYNC_COMMS)
-    cache_internal_append_unique(PROJECT_EXPORT_DEFINES ASYNCHRONOUS_CLIENT)
-    ADD_DEFINITIONS(-DASYNCHRONOUS_CLIENT)
-ELSE (USE_ASYNC_COMMS)
-    message(STATUS "removing ASYNCHRONOUS_CLIENT")
-    cache_internal_remove(PROJECT_EXPORT_DEFINES ASYNCHRONOUS_CLIENT)
-    REMOVE_DEFINITIONS(-DASYNCHRONOUS_CLIENT)
+  set(ASYNCHRONOUS_CLIENT_DEFINE "#define ASYNCHRONOUS_CLIENT")
 ENDIF (USE_ASYNC_COMMS)
-
-
 
 
 #do we want to turn on the experimental clock skew detection?
@@ -149,6 +142,8 @@ IF (ENABLE_V10_COMPATIBILITY)
     ENDIF()
 ENDIF ()
 
+CONFIGURE_FILE(${CMAKE_MODULE_PATH}/ClientDefines.h.in
+${CMAKE_CURRENT_SOURCE_DIR}/App/include/MOOS/libMOOS/App/ClientDefines.h @ONLY)
 
 
 ##########################

--- a/cmake/ClientDefines.h.in
+++ b/cmake/ClientDefines.h.in
@@ -1,0 +1,3 @@
+#pragma once
+//this file is auto generated and defines various preprocessor macros needed by the CMOOSApp
+@ASYNCHRONOUS_CLIENT_DEFINE@


### PR DESCRIPTION
Currently, the downstream clients must set the preprocessor macro ASYNCHRONOUS_CLIENT based on the value that libMOOS was compiled with, or else the generated code headers will differ from the library, and this generally leads to a segmentation fault.

The MOOSConfig.cmake file sets this definition, but it is rather presumptuous that users of libMOOS will always be using CMake and always be compiling from a local source tree.

This patch fixes this problem so that all users (CMake or not, local source tree or /usr/include package directory) can compile with the correct ASYNCHRONOUS_CLIENT settings.
