### PR TITLE
Respect BUILD_SHARED_LIBS configure option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,8 +63,13 @@ if(UPDATE_GIT_VERSION_INFO)
 	include(GitInfo)
 endif()
 
-# We want to create dynamic libraries
-set(BUILD_SHARED_LIBS true)
+# Do we want to create dynamic libraries?
+option(BUILD_SHARED_LIBS "Build lib${PROJECTNAME} as a shared library" OFF)
+if (BUILD_SHARED_LIBS)
+    message("-- Building lib${PROJECTNAME} as a shared library")
+else()
+    message("-- Building lib${PROJECTNAME} as a static library")
+endif()
 
 # Enable Doxygen build with 'make doxygen'
 option(ENABLE_DOXYGEN "Enable a 'make doc' target for Doxygen documentation")

--- a/Core/libMOOS/CMakeLists.txt
+++ b/Core/libMOOS/CMakeLists.txt
@@ -234,7 +234,7 @@ cache_internal_append_unique(PROJECT_EXPORT_LIBS
 # This is boilerplate.  Any extra libs you want to link should be in the '..._DEPEND_...'
 # variables
 include_directories(${${LIBNAME}_INCLUDE_DIRS} ${${LIBNAME}_DEPEND_INCLUDE_DIRS})
-add_library(${LIBNAME} STATIC ${SOURCES} ${PUBLIC_HEADERS})
+add_library(${LIBNAME} ${SOURCES} ${PUBLIC_HEADERS})
 target_link_libraries(${LIBNAME} ${${LIBNAME}_DEPEND_LIBRARIES})
 
 


### PR DESCRIPTION
Fix Issue #4

Commit c1a38274ba1b195106e7e92a9e1ba6021e328159 made libMOOS a static library. Yet the top CMakeLists wanted to always create a shared library.

This commit restores the option to make libMOOS shared.

BUILD_SHARED_LIBS is respected as a configure time option. Defaults to OFF as that was the current behaviour.