### PR TITLE
Add missing thread dependency to MOOSConfig.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -227,7 +227,7 @@ install(
 )
 
 # Headers are all combined into one common 'include' dir when MOOS is installed
-set(MOOS_INCLUDE_DIRS "include")
+set(MOOS_INCLUDE_DIRS "\${CMAKE_CURRENT_LIST_DIR}/../../../include")
 set(CONFIG_FILE "${PROJECT_BINARY_DIR}/MOOSInstallConfig.cmake")
 configure_file( "MOOSConfig.cmake.in" ${CONFIG_FILE} @ONLY )
 install(

--- a/Core/libMOOS/CMakeLists.txt
+++ b/Core/libMOOS/CMakeLists.txt
@@ -195,7 +195,7 @@ mark_as_advanced(TIME_WARP_AGGLOMERATION_CONSTANT)
 # install headers
 install(
     DIRECTORY ${INCLUDE_ROOTS}
-    DESTINATION include
+    DESTINATION .
     FILES_MATCHING PATTERN "*.h" PATTERN "*.hxx"
 )
 

--- a/MOOSConfig.cmake.in
+++ b/MOOSConfig.cmake.in
@@ -8,6 +8,11 @@ include(${exports_file})
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(MOOS DEFAULT_MSG exports_file)
 
+include(CMakeFindDependencyMacro)
+set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
+set(THREADS_PREFER_PTHREAD_FLAG TRUE)
+find_dependency(Threads REQUIRED)
+
 # Support existing projects that expect to find MOOS_LIBRARIES and
 # MOOS_INCLUDE_DIRS variables.
 # MOOS_INCLUDE_DIRS is no longer needed, as CMake brings


### PR DESCRIPTION
- This is necessary to bring the Threads::Threads target into scope for
  projects that depend on core-moos.

- Also fix header path for 'install' target.