### PR TITLE
Fix broken compiler version check

### DIFF
--- a/cmake/SystemUtilityFunctions.cmake
+++ b/cmake/SystemUtilityFunctions.cmake
@@ -83,25 +83,15 @@ endfunction()
 # Returns the first line of the compiler --version result.
 # Need to know if using gcc or clang.
 function( moos_get_compiler_version COMPILER_VERSION )
-  if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-    execute_process(COMMAND clang++ --version
-                    COMMAND head -n1
-                    OUTPUT_VARIABLE compiler_info
-                    OUTPUT_STRIP_TRAILING_WHITESPACE)
-
-  elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-    execute_process(COMMAND g++ --version
-                    COMMAND head -n1
-                    OUTPUT_VARIABLE compiler_info
-                    OUTPUT_STRIP_TRAILING_WHITESPACE)
-
-  endif()
+  execute_process(COMMAND "${CMAKE_CXX_COMPILER}" --version
+                  COMMAND head -n1
+                  OUTPUT_VARIABLE compiler_info
+                  OUTPUT_STRIP_TRAILING_WHITESPACE)
 
   # replace any forward slashes with a -, the submission name changes at
   # different stages otherwise, resulting in apparent multiple commits
-  string(REGEX REPLACE "/" "-" compiler_info ${compiler_info})
+  string(REGEX REPLACE "/" "-" compiler_info "${compiler_info}")
   set( ${COMPILER_VERSION} "${compiler_info}" PARENT_SCOPE )
-
 endfunction()
 
 ###########################################################################


### PR DESCRIPTION
- Previously assumed that the compiler was in the current path
  and was either called 'g++' or 'clang++'. That's not... always
  the case.
- There's still a fragile assumption that the compiler provides a
  '--version' option.