### PR TITLE
Avoid sending uninitialized bytes during handshake

### DIFF
--- a/Core/libMOOS/Comms/MOOSCommClient.cpp
+++ b/Core/libMOOS/Comms/MOOSCommClient.cpp
@@ -1125,7 +1125,11 @@ bool CMOOSCommClient::HandShake()
         }
 		
 		//announce the protocl we will be talking...
-		m_pSocket->iSendMessage((void*)MOOS_PROTOCOL_STRING, MOOS_PROTOCOL_STRING_BUFFER_SIZE);
+		// We use strncpy to explicitly pad the destination buffer with
+		// nulls, so the handshake message will not contain random bytes.
+		char buff[MOOS_PROTOCOL_STRING_BUFFER_SIZE];
+		strncpy(buff, MOOS_PROTOCOL_STRING, MOOS_PROTOCOL_STRING_BUFFER_SIZE);
+		m_pSocket->iSendMessage(buff, MOOS_PROTOCOL_STRING_BUFFER_SIZE);
 
 		//a little bit of handshaking..we need to say who we are
 		CMOOSMsg Msg(MOOS_DATA,HandShakeKey(),(char *)m_sMyName.c_str());

--- a/Core/libMOOS/Comms/XPCTcpSocket.cpp
+++ b/Core/libMOOS/Comms/XPCTcpSocket.cpp
@@ -143,7 +143,7 @@ void XPCTcpSocket::vListen(int _iNumPorts)
     }
 }       
 
-int XPCTcpSocket::iSendMessage(void *_vMessage, int _iMessageSize)
+int XPCTcpSocket::iSendMessage(const void*_vMessage, int _iMessageSize)
 {
     int iNumBytes;  // Stores the number of bytes sent
     

--- a/Core/libMOOS/Comms/include/MOOS/libMOOS/Comms/XPCTcpSocket.h
+++ b/Core/libMOOS/Comms/include/MOOS/libMOOS/Comms/XPCTcpSocket.h
@@ -56,7 +56,7 @@ public:
     XPCTcpSocket(short int _iSocketFd) : XPCSocket(_iSocketFd) { };
 
     // Sends a message to a connected host. The number of bytes sent is returned
-    int iSendMessage(void *_vMessage, int _iMessageSize);
+    int iSendMessage(const void *_vMessage, int _iMessageSize);
 
     // Receives a TCP message 
     int iRecieveMessage(void *_vMessage, int _iMessageSize, int _iOption = 0);


### PR DESCRIPTION
- The handshake protocol string stored in MOOS_PROTOCOL_STRING
   is not guaranteed to be 32 bytes long (and is actually much shorter),
   yet it is transmitted as if it is 32 bytes long. Which results in random
   bytes from memory being sent across the wire during handshake.
- This change causes the handshake protocol to be padded with null
   values instead.