### PR TITLE
UpdateSummaryVar improvements

### DIFF
--- a/Core/libMOOS/DB/MOOSDB.cpp
+++ b/Core/libMOOS/DB/MOOSDB.cpp
@@ -1205,7 +1205,6 @@ void CMOOSDB::UpdateSummaryVar()
         ss<<std::left<<std::setw(2);
         ss<<p->second.m_cDataType<<" ";
 
-        ss<<std::left<<std::setw(20);
         switch(p->second.m_cDataType)
         {
             case MOOS_DOUBLE:

--- a/Core/libMOOS/DB/MOOSDB.cpp
+++ b/Core/libMOOS/DB/MOOSDB.cpp
@@ -1208,7 +1208,6 @@ void CMOOSDB::UpdateSummaryVar()
         ss<<std::left<<std::setw(20);
         switch(p->second.m_cDataType)
         {
-            ss<<std::left<<std::setw(25);
             case MOOS_DOUBLE:
                 ss<<p->second.m_dfVal<<" ";break;
             case MOOS_STRING:
@@ -1221,7 +1220,6 @@ void CMOOSDB::UpdateSummaryVar()
 
                 break;
             }
-                ss<<p->second.m_sVal<<" ";break;
             case MOOS_BINARY_STRING:
             {
                 unsigned int s = p->second.m_sVal.size();

--- a/Core/libMOOS/DB/MOOSDB.cpp
+++ b/Core/libMOOS/DB/MOOSDB.cpp
@@ -1208,7 +1208,8 @@ void CMOOSDB::UpdateSummaryVar()
         switch(p->second.m_cDataType)
         {
             case MOOS_DOUBLE:
-                ss<<p->second.m_dfVal<<" ";break;
+                ss<<p->second.m_dfVal;
+                break;
             case MOOS_STRING:
             {
                 unsigned int s = p->second.m_sVal.size();
@@ -1224,16 +1225,15 @@ void CMOOSDB::UpdateSummaryVar()
                 unsigned int s = p->second.m_sVal.size();
                 std::string bss;
                 if(s<1024)
-                    bss = MOOSFormat("*binary* %-4d B  ",s);
+                    bss = MOOSFormat("*binary* %-4d B",s);
                 else if(s<1024*1024)
-                    bss = MOOSFormat("*binary* %.3f KB ",s/(1024.0));
+                    bss = MOOSFormat("*binary* %.3f KB",s/(1024.0));
                 else
-                    bss = MOOSFormat("*binary* %.3f MB ",s/(1024.0*1024.0));
+                    bss = MOOSFormat("*binary* %.3f MB",s/(1024.0*1024.0));
 
                 ss<<bss;
                 break;
             }
-
         }
 
 


### PR DESCRIPTION
This addresses a bug where channels with message type of MOOS_NOT_SET caused the next line in the message to be indented by 19 spaces.

It also removes some unreachable code and removes the trailing whitespace on the end of lines which aren't for channels with string content that is 20 or more characters long.