### PR TITLE
fix thirdparty head glob pattern to also include .hpp files

### DIFF
--- a/Core/libMOOS/CMakeLists.txt
+++ b/Core/libMOOS/CMakeLists.txt
@@ -196,7 +196,7 @@ mark_as_advanced(TIME_WARP_AGGLOMERATION_CONSTANT)
 install(
     DIRECTORY ${INCLUDE_ROOTS}
     DESTINATION .
-    FILES_MATCHING PATTERN "*.h" PATTERN "*.hxx"
+    FILES_MATCHING PATTERN "*.h" PATTERN "*.hxx" PATTERN "*.hpp"
 )
 
 # install libraries


### PR DESCRIPTION
Currently when core-moos gets installed, getpot.hpp fails to get copied over. The cause is that in the CMakeLists.txt, the file glob pattern that collects the header files doesn't include the .hpp extension  This causes the build of moos-essential to fail.  The pull request fixes it.