### PR TITLE
rename UseMOOS.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,7 +190,7 @@ add_subdirectory(Core)
 export(
     TARGETS MOOS
     NAMESPACE MOOS::
-    FILE UseMOOS.cmake
+    FILE UseMOOSTargets.cmake
 )
 
 # Support existing projects that expect to find MOOS_LIBRARIES and
@@ -222,7 +222,7 @@ set(PROJECT_CONFIG_PATH "lib/cmake/MOOS")
 install(
     EXPORT MOOS
     NAMESPACE MOOS::
-    FILE UseMOOS.cmake
+    FILE UseMOOSTargets.cmake
     DESTINATION ${PROJECT_CONFIG_PATH}
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,7 +190,7 @@ add_subdirectory(Core)
 export(
     TARGETS MOOS
     NAMESPACE MOOS::
-    FILE UseMOOSTargets.cmake
+    FILE MOOSTargets.cmake
 )
 
 # Support existing projects that expect to find MOOS_LIBRARIES and
@@ -222,7 +222,7 @@ set(PROJECT_CONFIG_PATH "lib/cmake/MOOS")
 install(
     EXPORT MOOS
     NAMESPACE MOOS::
-    FILE UseMOOSTargets.cmake
+    FILE MOOSTargets.cmake
     DESTINATION ${PROJECT_CONFIG_PATH}
 )
 

--- a/MOOSConfig.cmake.in
+++ b/MOOSConfig.cmake.in
@@ -2,7 +2,7 @@
 
 # Pick up the auto-generated file which knows how to add the imported library
 # targets for the libraries that MOOS exports.
-set(exports_file "${CMAKE_CURRENT_LIST_DIR}/UseMOOS.cmake")
+set(exports_file "${CMAKE_CURRENT_LIST_DIR}/UseMOOSTargets.cmake")
 include(${exports_file})
 
 include(FindPackageHandleStandardArgs)

--- a/MOOSConfig.cmake.in
+++ b/MOOSConfig.cmake.in
@@ -2,7 +2,7 @@
 
 # Pick up the auto-generated file which knows how to add the imported library
 # targets for the libraries that MOOS exports.
-set(exports_file "${CMAKE_CURRENT_LIST_DIR}/UseMOOSTargets.cmake")
+set(exports_file "${CMAKE_CURRENT_LIST_DIR}/MOOSTargets.cmake")
 include(${exports_file})
 
 include(FindPackageHandleStandardArgs)


### PR DESCRIPTION
I've submitted a pull request to add MOOS to the vcpkg package manager. By convention the cmake file that contains the exported targets is named something like `<project-name>Targets.cmake`.  This pull request renames the file UseMOOS.cmake to UseMOOSTargets.cmake to facilitate easier integration into vcpkg.  This changes is transparent to the use of MOOS as well as the script FindMOOS.cmake.