### PR TITLE
Replace uses of std::auto_ptr with a basic ScopedPtr class

### DIFF
--- a/Core/libMOOS/Comms/MOOSCommClient.cpp
+++ b/Core/libMOOS/Comms/MOOSCommClient.cpp
@@ -53,6 +53,7 @@
 #include "MOOS/libMOOS/Utils/MOOSUtils.h"
 #include "MOOS/libMOOS/Utils/MOOSException.h"
 #include "MOOS/libMOOS/Utils/MOOSScopedLock.h"
+#include "MOOS/libMOOS/Utils/MOOSScopedPtr.h"
 #include "MOOS/libMOOS/Utils/ConsoleColours.h"
 #include "MOOS/libMOOS/Utils/ThreadPriority.h"
 #include "MOOS/libMOOS/Utils/IPV4Address.h"
@@ -1718,7 +1719,7 @@ bool CMOOSCommClient::UpdateMOOSSkew(double dfRqTime, double dfTxTime, double df
 	{
 		// Make a fresh skew filter
 		//m_pSkewFilter = std::auto_ptr<MOOS::CMOOSSkewFilter>(new MOOS::CMOOSConditionedSkewFilter);
-		m_pSkewFilter = std::auto_ptr<MOOS::CMOOSSkewFilter>(new MOOS::CMOOSSkewFilter);
+		m_pSkewFilter = MOOS::ScopedPtr<MOOS::CMOOSSkewFilter>(new MOOS::CMOOSSkewFilter);
 		if (!m_pSkewFilter.get())
 			return false;
 	}

--- a/Core/libMOOS/Comms/include/MOOS/libMOOS/Comms/MOOSCommClient.h
+++ b/Core/libMOOS/Comms/include/MOOS/libMOOS/Comms/MOOSCommClient.h
@@ -39,6 +39,7 @@
 
 #include "MOOS/libMOOS/Utils/MOOSLock.h"
 #include "MOOS/libMOOS/Utils/MOOSThread.h"
+#include "MOOS/libMOOS/Utils/MOOSScopedPtr.h"
 #include "MOOS/libMOOS/Utils/Macros.h"
 #include "MOOS/libMOOS/Comms/MOOSCommObject.h"
 #include "MOOS/libMOOS/Comms/ActiveMailQueue.h"
@@ -592,7 +593,7 @@ protected:
     bool m_bDoLocalTimeCorrection;
     
     /** Skew filter keeps track of clock skew with server */
-    std::auto_ptr< MOOS::CMOOSSkewFilter > m_pSkewFilter;
+    MOOS::ScopedPtr< MOOS::CMOOSSkewFilter > m_pSkewFilter;
     
     /**
      * list of names of active mail queues for each message name

--- a/Core/libMOOS/DB/MOOSDB.cpp
+++ b/Core/libMOOS/DB/MOOSDB.cpp
@@ -40,7 +40,7 @@
 #include "MOOS/libMOOS/MOOSVersion.h"
 #include "MOOS/libMOOS/GitVersion.h"
 #include "MOOS/libMOOS/DB/MOOSDBLogger.h"
-
+#include "MOOS/libMOOS/Utils/MOOSScopedPtr.h"
 
 
 
@@ -326,7 +326,7 @@ bool CMOOSDB::Run(int argc,  char * argv[] )
 
 	//if either the mission file or command line have set a webserver port then launch one
 	if(nWebServerPort>0)
-		m_pWebServer = std::auto_ptr<CMOOSDBHTTPServer> (new CMOOSDBHTTPServer(GetDBPort(), nWebServerPort));
+		m_pWebServer.reset(new CMOOSDBHTTPServer(GetDBPort(), nWebServerPort));
 
 	double dfClientTimeout = 5.0;
 	m_MissionReader.GetValue("ClientTimeout",dfClientTimeout);
@@ -426,12 +426,12 @@ bool CMOOSDB::Run(int argc,  char * argv[] )
     if(bSingleThreaded)
     {
         std::cout<<MOOS::ConsoleColours::yellow()<<"warning : running in single threaded mode performance will be affected by poor networks\n"<<MOOS::ConsoleColours::reset();
-		m_pCommServer = std::auto_ptr<CMOOSCommServer> (new CMOOSCommServer);
+        m_pCommServer.reset(new CMOOSCommServer);
     }
     else
     {
         //std::cerr<<MOOS::ConsoleColours::green()<<"running in multi-threaded mode\n"<<MOOS::ConsoleColours::reset();
-		m_pCommServer = std::auto_ptr<CMOOSCommServer> (new MOOS::ThreadedCommServer);
+        m_pCommServer.reset(new MOOS::ThreadedCommServer);
     }
 
     m_pCommServer->SetQuiet(m_bQuiet);

--- a/Core/libMOOS/DB/include/MOOS/libMOOS/DB/MOOSDB.h
+++ b/Core/libMOOS/DB/include/MOOS/libMOOS/DB/MOOSDB.h
@@ -34,6 +34,7 @@
 #include <memory>
 
 #include "MOOS/libMOOS/Utils/ProcessConfigReader.h"
+#include "MOOS/libMOOS/Utils/MOOSScopedPtr.h"
 
 #include "MOOS/libMOOS/Comms/CommsTypes.h"
 #include "MOOS/libMOOS/Comms/MOOSMsg.h"
@@ -151,10 +152,10 @@ private:
     HASH_MAP_TYPE<std::string,std::set< MOOS::MsgFilter > > m_ClientFilters;
 
     //pointer to a webserver if one is needed
-    std::auto_ptr<CMOOSDBHTTPServer> m_pWebServer;
+    MOOS::ScopedPtr<CMOOSDBHTTPServer> m_pWebServer;
 
     //pointer to the comms server (could be a threaded one but base class is CMOOSCommServer
-    std::auto_ptr<CMOOSCommServer> m_pCommServer;
+    MOOS::ScopedPtr<CMOOSCommServer> m_pCommServer;
 
     MOOS::MOOSDBLogger m_EventLogger;
 

--- a/Core/libMOOS/Utils/CommandLineParser.cpp
+++ b/Core/libMOOS/Utils/CommandLineParser.cpp
@@ -33,7 +33,7 @@
  */
 
 #include "MOOS/libMOOS/Utils/CommandLineParser.h"
-
+#include "MOOS/libMOOS/Utils/MOOSScopedPtr.h"
 #include "MOOS/libMOOS/Thirdparty/getpot/GetPot"
 
 
@@ -61,7 +61,7 @@ CommandLineParser::CommandLineParser(int argc,  char * argv[])
 bool CommandLineParser::Open(int argc,  char * argv[])
 {
 
-	pcl_ = std::auto_ptr<GetPot>(new GetPot(argc,argv) );
+	pcl_.reset( new GetPot(argc,argv) );
 	return true;
 }
 

--- a/Core/libMOOS/Utils/include/MOOS/libMOOS/Utils/CommandLineParser.h
+++ b/Core/libMOOS/Utils/include/MOOS/libMOOS/Utils/CommandLineParser.h
@@ -28,7 +28,9 @@
 
 #ifndef COMMANDLINEPARSER_H_
 #define COMMANDLINEPARSER_H_
-#include <memory>
+
+#include "MOOS/libMOOS/Utils/MOOSScopedPtr.h"
+
 #include <vector>
 #include <string>
 #include <stdint.h>
@@ -94,7 +96,7 @@ public:
 	 */
 	bool VariableExists(const std::string & var);
 private:
-	std::auto_ptr<GetPot> pcl_;
+	MOOS::ScopedPtr<GetPot> pcl_;
 
 };
 

--- a/Core/libMOOS/Utils/include/MOOS/libMOOS/Utils/MOOSScopedPtr.h
+++ b/Core/libMOOS/Utils/include/MOOS/libMOOS/Utils/MOOSScopedPtr.h
@@ -1,0 +1,77 @@
+///////////////////////////////////////////////////////////////////////////
+//
+//   This file is part of the MOOS project
+//
+//   MOOS : Mission Oriented Operating Suite A suit of
+//   Applications and Libraries for Mobile Robotics Research
+//   Copyright (C) Paul Newman
+//
+//   This software was written by Paul Newman at MIT 2001-2002 and
+//   the University of Oxford 2003-2013
+//
+//   email: pnewman@robots.ox.ac.uk.
+//
+//   This source code and the accompanying materials
+//   are made available under the terms of the GNU Lesser Public License v2.1
+//   which accompanies this distribution, and is available at
+//   http://www.gnu.org/licenses/lgpl.txtgram is distributed in the hope that it will be useful,
+//   but WITHOUT ANY WARRANTY; without even the implied warranty of
+//   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//
+////////////////////////////////////////////////////////////////////////////
+/*
+ * MOOSScopedPtr.h
+ *
+ *  Created on: Jun 19, 2018
+ *      Author: arh
+ */
+
+#ifndef MOOSSCOPEDPTR_H
+#define MOOSSCOPEDPTR_H
+
+namespace MOOS {
+
+// This is a very basic RAII class that owns a resource and ensures that it is
+// correctly deleted when the ScopedPtr goes out of scope.
+// This class behaves like an auto_ptr, but without the surprising copy and
+// assignment behaviour.  If MOOS transitions to C++11 then all instances of
+// ScopedPtr can be trivially replaced with std::unique_ptr.
+template <class T>
+class ScopedPtr {
+ public:
+  typedef T element_type;
+
+  explicit ScopedPtr(T* p = 0) : ptr_(p) {}
+  ~ScopedPtr() { delete ptr_; }
+
+ private:
+  // Copy and assign do not fit with the single-owner semantics of ScopedPtr,
+  // so they are left unimplemented.
+  ScopedPtr(ScopedPtr const& p);
+  ScopedPtr& operator=(ScopedPtr& p);
+
+ public:
+  T& operator*() const { return *ptr_; }
+  T* operator->() const { return ptr_; }
+
+  T* get() const { return ptr_; }
+
+  T* release() {
+    T* temp = ptr_;
+    ptr_ = 0;
+    return temp;
+  }
+
+  void reset(T* p = 0) {
+    if (ptr_ != p)
+      delete ptr_;
+    ptr_ = p;
+  }
+
+ private:
+  T* ptr_;
+};
+
+}  // namespace MOOS
+
+#endif  // MOOSSCOPEDPTR_H

--- a/Core/libMOOS/Utils/include/MOOS/libMOOS/Utils/ProcInfo.h
+++ b/Core/libMOOS/Utils/include/MOOS/libMOOS/Utils/ProcInfo.h
@@ -31,7 +31,8 @@
 #ifndef PROCINFO_H_
 #define PROCINFO_H_
 
-#include <memory>
+#include "MOOS/libMOOS/Utils/MOOSScopedPtr.h"
+
 /*
  * simple class which estimates CPU usage for the calling process.
  */
@@ -62,7 +63,7 @@ public:
 
 private:
 	class Impl;
-	std::auto_ptr<Impl> Impl_;
+	MOOS::ScopedPtr<Impl> Impl_;
 };
 
 }


### PR DESCRIPTION
- std::auto_ptr is deprecated because of its surprising semantics.
- We can't use std::unique_ptr because it requires C++11.
- ScopedPtr has almost the same API as auto_ptr, but does not implement copy and assign.