### PR TITLE
Fix compatibility with CMake < 3.0

### DIFF
--- a/MOOSConfig.cmake.in
+++ b/MOOSConfig.cmake.in
@@ -8,10 +8,9 @@ include(${exports_file})
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(MOOS DEFAULT_MSG exports_file)
 
-include(CMakeFindDependencyMacro)
 set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 set(THREADS_PREFER_PTHREAD_FLAG TRUE)
-find_dependency(Threads REQUIRED)
+find_package(Threads REQUIRED)
 
 # Support existing projects that expect to find MOOS_LIBRARIES and
 # MOOS_INCLUDE_DIRS variables.


### PR DESCRIPTION
The CMakeFindDependencyMacro is a 3.0 feature, while core-moos supports as low as [CMake 2.8](https://github.com/themoos/core-moos/blob/64c9750f53b0d049a4cd9ec771bc1dc397a9fb65/CMakeLists.txt\#L7). The issue isn't apparent when building core-moos alone, however, when a dependent project (say, essential-moos) tries to use it an error is produced, citing the lack of CMakeFindDependencyMacro, and therefore find_dependency. This commit uses the slightly different find_package function, which is supported on CMake 2.8 systems.

To reproduce, boot a system with CMake 2.8 (I'm using CentOS 7), clone both core-moos and essential-moos, cmake && make core-moos (there shouldn't be any errors), then try to cmake essential-moos. The error should present itself. 

The alternative to this patch is to explicitly set 3.0 as the minimum requirement, though this may have negative impact on downstream projects.

Testing would be appreciated from whoever can.

Thanks!