### PR TITLE
Comment out debug print in AsyncCommClient

### DIFF
--- a/Core/libMOOS/Comms/MOOSAsyncCommClient.cpp
+++ b/Core/libMOOS/Comms/MOOSAsyncCommClient.cpp
@@ -342,7 +342,7 @@ bool MOOSAsyncCommClient::MonitorAndLimitWriteSpeed()
             static_cast<unsigned int> (TotalDelay);
     if (sleep_ms > 0)
     {
-        std::cerr << "I'm sleeping for " << TotalDelay << " ms ("<<TotalDelay/GetMOOSTimeWarp()<<" real ms)\n";
+        //std::cerr << "I'm sleeping for " << TotalDelay << " ms ("<<TotalDelay/GetMOOSTimeWarp()<<" real ms)\n";
         MOOSPause(sleep_ms,false);
     }
 


### PR DESCRIPTION
Follows convention of other debug lines in the file, comment them out (rather than remove). Fixes excess printing to console applications that use AsyncCommClient.