### PR TITLE
fix compiler warnings due to incorrect headers

### DIFF
--- a/Core/libMOOS/Comms/MOOSCommServer.cpp
+++ b/Core/libMOOS/Comms/MOOSCommServer.cpp
@@ -54,7 +54,7 @@
 using namespace std;
 
 #ifndef _WIN32
-    #include <sys/signal.h>
+    #include <signal.h>
 #endif
 
 #define TOLERABLE_SILENCE 5.0

--- a/Core/libMOOS/Utils/include/MOOS/libMOOS/Utils/MOOSLinuxSerialPort.h
+++ b/Core/libMOOS/Utils/include/MOOS/libMOOS/Utils/MOOSLinuxSerialPort.h
@@ -39,7 +39,7 @@
 
 #ifndef _WIN32
     #include <fcntl.h>
-    #include <sys/signal.h>
+    #include <signal.h>
     #include <sys/types.h>
     #include <termios.h>
         #include <unistd.h>

--- a/Core/libMOOS/Utils/include/MOOS/libMOOS/Utils/MOOSMemoryMapped.h
+++ b/Core/libMOOS/Utils/include/MOOS/libMOOS/Utils/MOOSMemoryMapped.h
@@ -48,7 +48,7 @@
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/mman.h>
-#include <sys/fcntl.h>
+#include <fcntl.h>
 #include <sys/stat.h>
 #include <ctype.h>
 #endif 


### PR DESCRIPTION
When getting MOOS to compile on Alpine Linux musl libc warnings appear due to incorrect paths to includes being used. This fixes these warnings.

Other warnings that appear are whitespace warnings fixed in #57.
