### PR TITLE
Remove several unneeded training semicolons

### DIFF
--- a/Core/libMOOS/Comms/EndToEndAudit.cpp
+++ b/Core/libMOOS/Comms/EndToEndAudit.cpp
@@ -112,4 +112,4 @@ bool EndToEndAudit::TransmitWorker(){
     return true;
 }
 
-};
+}

--- a/Core/libMOOS/Comms/SuicidalSleeper.cpp
+++ b/Core/libMOOS/Comms/SuicidalSleeper.cpp
@@ -195,7 +195,7 @@ bool SuicidalSleeper::Work()
 }
 
 
-};//namespace MOOS
+}//namespace MOOS
 
 
 

--- a/Core/libMOOS/Comms/include/MOOS/libMOOS/Comms/EndToEndAudit.h
+++ b/Core/libMOOS/Comms/include/MOOS/libMOOS/Comms/EndToEndAudit.h
@@ -78,6 +78,6 @@ private:
 
 
 };
-};
+}
 
 #endif

--- a/Core/libMOOS/DB/include/MOOS/libMOOS/DB/MsgFilter.h
+++ b/Core/libMOOS/DB/include/MOOS/libMOOS/DB/MsgFilter.h
@@ -46,5 +46,5 @@ protected:
 	std::pair<std::string,std::string> filters_;
 	double period_;
 };
-};
+}
 #endif

--- a/Core/libMOOS/Utils/ConsoleColours.cpp
+++ b/Core/libMOOS/Utils/ConsoleColours.cpp
@@ -10,4 +10,4 @@
 namespace MOOS
 {
 	bool ConsoleColours::disable_color_=false;
-};
+}

--- a/Core/libMOOS/Utils/IPV4Address.cpp
+++ b/Core/libMOOS/Utils/IPV4Address.cpp
@@ -65,7 +65,7 @@ IPV4Address::~IPV4Address() {
 IPV4Address::IPV4Address(const std::string & host, uint16_t p):host_(host),port_(p)
 {
 
-};
+}
 IPV4Address::IPV4Address(const std::string & host_and_port)
 {
 	std::string tmp(host_and_port);

--- a/Core/libMOOS/Utils/KeyboardCapture.cpp
+++ b/Core/libMOOS/Utils/KeyboardCapture.cpp
@@ -122,4 +122,4 @@ bool KeyboardCapture::GetKeyboardInput(char & input)
 }
 
 
-};
+}

--- a/Core/libMOOS/Utils/MOOSUtilityFunctions.cpp
+++ b/Core/libMOOS/Utils/MOOSUtilityFunctions.cpp
@@ -173,7 +173,7 @@ namespace MOOS
 		return atof(sNum.c_str());
 	}
 
-};
+}
 
 
 void    SetMOOSSkew(double dfSkew)

--- a/Core/libMOOS/Utils/PeriodicEvent.cpp
+++ b/Core/libMOOS/Utils/PeriodicEvent.cpp
@@ -155,4 +155,4 @@ namespace MOOS
 	}
 
 
-};
+}

--- a/Core/libMOOS/Utils/include/MOOS/libMOOS/Utils/CommsTools.h
+++ b/Core/libMOOS/Utils/include/MOOS/libMOOS/Utils/CommsTools.h
@@ -10,6 +10,6 @@
 namespace MOOS
 {
     bool WaitForSocket(int fd, int nTimeoutSeconds);
-};
+}
 
 #endif /* COMMSTOOLS_H_ */

--- a/Core/libMOOS/Utils/include/MOOS/libMOOS/Utils/KeyboardCapture.h
+++ b/Core/libMOOS/Utils/include/MOOS/libMOOS/Utils/KeyboardCapture.h
@@ -39,6 +39,6 @@ private:
 
 
 };
-};
+}
 
 #endif

--- a/Core/libMOOS/Utils/include/MOOS/libMOOS/Utils/MemInfo.h
+++ b/Core/libMOOS/Utils/include/MOOS/libMOOS/Utils/MemInfo.h
@@ -38,7 +38,7 @@ namespace MOOS
 	size_t GetPeakMemoryUsage( );
 	size_t GetCurrentMemoryUsage( );
 
-};
+}
 
 
 #endif /* MEMINFO_H_ */

--- a/Core/libMOOS/Utils/include/MOOS/libMOOS/Utils/ThreadPriority.h
+++ b/Core/libMOOS/Utils/include/MOOS/libMOOS/Utils/ThreadPriority.h
@@ -51,6 +51,6 @@ namespace MOOS
 	 * @return
 	 */
 	bool GetThisThreadsPriority(int & Priority, int & MaxAllowed);
-};
+}
 
 #endif /* THREADPRIORITY_H_ */


### PR DESCRIPTION
When running with -pedantic, these semicolons are flagged as warnings. Some of the files are included in several places, causing the warning of one file to be written multiple times. This removed the trailing semicolons, and fixes the warning.

This PR, along with #57, would get rid of most of the errors I can see when compiling with `-Wall -Wextra -pedantic` on Ubuntu 18.04 and gcc 7.4.0.