### PR TITLE
Fix potential receiver lock-up on connection failure

### DIFF
--- a/Core/libMOOS/Comms/MOOSAsyncCommClient.cpp
+++ b/Core/libMOOS/Comms/MOOSAsyncCommClient.cpp
@@ -366,14 +366,18 @@ bool MOOSAsyncCommClient::ReadingLoop() {
         {
             if (!DoReading())
             {
+              const double StartTimeOfConnectionToTerminate =
+                  m_dfLastConnectionTime;
                 OutGoingQueue_.Push(
                                     CMOOSMsg(MOOS_TERMINATE_CONNECTION,
                                              "-quit-", 0));
 
-                //std::cout<<"reading failed!\n";
-
-                while (IsConnected())//wait for connection to terminate...
-                    MOOSPause(200);
+                while (IsConnected() &&
+                       m_dfLastConnectionTime ==
+                       StartTimeOfConnectionToTerminate) {
+                  //wait for connection to terminate...
+                  MOOSPause(200);
+                }
             }
 
         }

--- a/Core/libMOOS/Comms/MOOSCommClient.cpp
+++ b/Core/libMOOS/Comms/MOOSCommClient.cpp
@@ -105,6 +105,7 @@ CMOOSCommClient::CMOOSCommClient()
 	m_nOutPendingLimit = OUTBOX_PENDING_LIMIT;
 	m_nInPendingLimit = INBOX_PENDING_LIMIT;
 	m_bConnected = false;
+        m_dfLastConnectionTime = -1;
 	m_nFundamentalFreq = CLIENT_DEFAULT_FUNDAMENTAL_FREQ;
 	m_nNextMsgID=0;
 	m_bFakeSource = false;
@@ -977,6 +978,7 @@ bool CMOOSCommClient::ConnectToServer()
 		//suggestion to move this to here accpted by PMN on 21st Jan 2009
         //we must be connected for user callback to work..
         m_bConnected = true;
+        m_dfLastConnectionTime = MOOSLocalTime();
 
 
         if(m_pfnConnectCallBack!=NULL)

--- a/Core/libMOOS/Comms/include/MOOS/libMOOS/Comms/MOOSCommClient.h
+++ b/Core/libMOOS/Comms/include/MOOS/libMOOS/Comms/MOOSCommClient.h
@@ -462,6 +462,8 @@ protected:
 
     /** true if we are connected to the server */
     bool m_bConnected;
+    /** time of the last successful connection */
+    double m_dfLastConnectionTime;
     
     /** true if we want to be able to fake sources of messages (used by playback)*/
     bool m_bFakeSource;


### PR DESCRIPTION
- When a physical network disconnect occurs the read thread may stall
  and not detect the failure until the network is reconnected, at which
  point the clients disconnection and reconnection methods occur in
  quick succession.
- Previously this could cause a lock-up of the receive thread if the
  reconnection occurred whilst the thread was waiting for the connection
  to close.  As it had no mechanism to determine the age of the current
  connection it would erroneously assume that it was still waiting for
  the failed connection to close and continue to wait indefinitely.
  In this case, no new messages would ever be received by the client.