### PR TITLE
cmake: add a BUILD_TESTS option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,9 @@ if(ENABLE_DOXYGEN)
     include(UseDoxygen)
 endif()
 
+# Option to enable building of tests
+option(BUILD_TESTS "Build tests" ON)
+
 # Option to enable CDash testing
 option(CDASH_SUPPORT "Turn on testing targets that upload results to CDash" OFF)
 

--- a/Core/MOOSDB/CMakeLists.txt
+++ b/Core/MOOSDB/CMakeLists.txt
@@ -27,5 +27,6 @@ install(TARGETS ${EXECNAME}
   ARCHIVE DESTINATION lib
 )
 
-add_subdirectory(testing)
-
+if(BUILD_TESTS)
+  add_subdirectory(testing)
+endif()

--- a/Core/libMOOS/CMakeLists.txt
+++ b/Core/libMOOS/CMakeLists.txt
@@ -207,5 +207,7 @@ install(TARGETS MOOS
   ARCHIVE DESTINATION lib
 )
 
-add_subdirectory(testing)
+if(BUILD_TESTS)
+  add_subdirectory(testing)
+endif()
 


### PR DESCRIPTION
I needed a way to disable tests so I could use moos as a sub-project. This adds a `BUILD_TESTS` option.