### PR TITLE
delete ptr returned by BindMsgFunctor

### DIFF
--- a/Core/libMOOS/Comms/ActiveMailQueue.cpp
+++ b/Core/libMOOS/Comms/ActiveMailQueue.cpp
@@ -58,6 +58,10 @@ ActiveMailQueue::ActiveMailQueue(const std::string & Name) : Name_(Name)
 ActiveMailQueue::~ActiveMailQueue() {
 	// TODO Auto-generated destructor stub
 	Stop();
+	if(pClassMemberFunctionCallback_){
+		delete pClassMemberFunctionCallback_;
+		pClassMemberFunctionCallback_ = NULL;
+	}
 }
 
 std::string ActiveMailQueue::GetName()


### PR DESCRIPTION
found a minor resource leak on active queue when using a member function as a callback