### PR TITLE
Include functional to fix error C2039 and C2504

### DIFF
--- a/Core/libMOOS/Utils/MOOSUtilityFunctions.cpp
+++ b/Core/libMOOS/Utils/MOOSUtilityFunctions.cpp
@@ -47,6 +47,7 @@
 #include <time.h>
 #include <stdarg.h>
 #include <math.h>
+#include <functional>
 
 #ifndef _WIN32
 #include <unistd.h>


### PR DESCRIPTION
Hello, I'm a member of Microsoft VCPKG, when I built this port in an internal version of Visual Studio, it failed with following errors:
```
D:\buildtrees\moos-core\src\v10.4.0-b8b4dc3523.clean\Core\libMOOS\Utils\MOOSUtilityFunctions.cpp(380): error C2039: 'binary_function': is not a member of 'std'
D:\buildtrees\moos-core\src\v10.4.0-b8b4dc3523.clean\Core\libMOOS\Utils\MOOSUtilityFunctions.cpp(380): error C2504: 'binary_function': base class undefined
D:\buildtrees\moos-core\src\v10.4.0-b8b4dc3523.clean\Core\libMOOS\Utils\MOOSUtilityFunctions.cpp(380): error C2143: syntax error: missing ',' before '<'
```
The reason is new STL change, need include `<functional>` to fix them.